### PR TITLE
Update automatic_backups.yaml > Add "backup_location"

### DIFF
--- a/automation/automatic_backups.yaml
+++ b/automation/automatic_backups.yaml
@@ -58,6 +58,12 @@ blueprint:
       selector:
         text:
           type: password
+    backup_location:
+      name: "Backup Location"
+      description: "Set the backup location (needs to be added under 'Settings > System > Storage > Network Storage')"
+      default: "/backup"
+      selector:
+        backup_location:
     enable_daily:
       name: "Enable: Daily Backups"
       description: "Create a backup each day and store for a week"
@@ -112,6 +118,7 @@ blueprint:
               metadata: {}
               data:
                 name: "{{ name }}"
+                location: "{{ location }}"
                 encrypted: "{{ encrypted }}"
                 password: "{{ password }}"
                 keep_days: "{{ keep_days }}"
@@ -131,6 +138,7 @@ mode: single
 
 variables:
   encrypted: !input encrypted
+  location: !input backup_location
   password: !input backup_password
   enable_hourly: !input enable_hourly
   enable_daily: !input enable_daily
@@ -178,6 +186,7 @@ action:
                     service: auto_backup.backup
                     data:
                       name: "{{ name }}"
+                      location: "{{ location }}"
                       encrypted: "{{ encrypted }}"
                       password: "{{ password }}"
                       keep_days: "{{ keep_days }}"
@@ -227,6 +236,7 @@ action:
             service: auto_backup.backup
             data:
               name: "{{ name }}"
+              location: "{{ location }}"
               encrypted: "{{ encrypted }}"
               password: "{{ password }}"
               keep_days: "{{ keep_days }}"


### PR DESCRIPTION
Hi, I hope this PR is ok.

I made this change to the BP on my install, and thought it might be useful for the blueprint which has otherwise been awesome. This seems to work, though I only tested by instigating a daily backup (changed time and waited).

An issue I could see is noted [here](https://www.home-assistant.io/docs/blueprint/selectors/#backup-location-selector).

> # Backup location selector 
> This can only be used on an installation with a Supervisor (Operating System or Supervised). For installations of type Home Assistant Core or Home Assistant Container, an error will be displayed.